### PR TITLE
Change Markdown Parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
-    "core-js": "3",
-    "markdown-tree-parser": "^0.12.4"
+    "core-js": "3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,25 @@
-import mtp from 'markdown-tree-parser'
+import mtp from '@/parse/index.js'
 
 const text = `
 # Heading 1
 ## Heading 2
 test **Markdown**
+
+- [ ] checklist1
+  - [ ] checklist-child
+- [ ] checklist2
+- [ ] checklist3
+
+- list
+  - list2
+- list3
+
+1. aaa
+  2. bbb
+3. ccc
+
+[hoge](http://localhost)
 `
 const tree = mtp(text);
-console.log(tree.dump());
+console.log(tree);
+console.log(JSON.stringify(tree, null, '  '));

--- a/src/parse/Tree.js
+++ b/src/parse/Tree.js
@@ -1,0 +1,5 @@
+export default class Tree {
+  constructor(ast) {
+    this.ast = ast;
+  }
+};

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -1,0 +1,10 @@
+import parser from './parser/index.js';
+import Tree from './Tree.js';
+
+const mdParse = mdString => {
+  const ast = parser(mdString);
+
+  return new Tree(ast);
+};
+
+export default mdParse.parse = parser;

--- a/src/parse/nodes/Node.js
+++ b/src/parse/nodes/Node.js
@@ -1,0 +1,6 @@
+export default class Node {
+  constructor(name, type) {
+    this.name = name;
+    this.type = type;
+  }
+};

--- a/src/parse/nodes/block.js
+++ b/src/parse/nodes/block.js
@@ -1,0 +1,106 @@
+import Node from './Node.js';
+import inlineParser from '../parser/inline.js';
+import inline from './inline.js';
+import SyntaxError from '../parser/syntax-error.js';
+
+class Paragraph extends Node {
+  constructor(text) {
+    super('paragraph', 'block');
+    this.values = inlineParser(text);
+  }
+}
+
+class Horizontal extends Node {
+  constructor(text) {
+    super('horizontal', 'block');
+    this.values = [];
+  }
+}
+
+class Code extends Node {
+  constructor(text, syntax) {
+    super('code', 'block');
+    this.syntax = syntax;
+    this.values = [
+      new inline.Text(text)
+    ];
+  }
+}
+
+class Blockquote extends Node {
+  constructor(text, level) {
+    super('blockquote', 'block');
+    this.level = level;
+    this.values = [
+      new inline.Text(text)
+    ];
+  }
+}
+
+class Heading extends Node {
+  constructor(text, level) {
+    if (level === 0 || level > 6) {
+      throw new SyntaxError('Invalid heading: heading support only between H1 and H6');
+    }
+    super('heading', 'block');
+    this.level = level;
+    this.values = inlineParser(text);
+  }
+}
+
+class List extends Node {
+  constructor(text, level) {
+    super('list', 'block');
+    this.level = level;
+    this.values = inlineParser(text);
+  }
+}
+
+class OrderedList extends Node {
+  constructor(text, order, level) {
+    super('orderedlist', 'block');
+    this.level = level;
+    this.order = order;
+    this.values = inlineParser(text);
+  }
+}
+
+class CheckList extends Node {
+  constructor(text, checked, level) {
+    super('checklist', 'block');
+    this.level = level;
+    this.checked = checked;
+    this.values = inlineParser(text);
+  }
+}
+
+class Table extends Node {
+  constructor(_rows) {
+    super('table', 'block');
+    const [heading, separator, ...rows] = _rows.map(line => line.replace(/^\||\|$/g, '').split('|'));
+    this.headings = heading.map(cell => cell.trim());
+    this.aligns = separator.map(cell => {
+      cell = cell.trim();
+      let align = 'left';
+      if (cell[cell.length - 1] === ':') {
+        align = cell[0] === ':' ? 'center': 'right';
+      }
+      return align;
+    });
+    this.rows = rows.map(row => {
+      return row.map(cell => inlineParser(cell.trim()));
+    });
+  }
+}
+
+export default {
+  Paragraph,
+  Horizontal,
+  Code,
+  Blockquote,
+  Heading,
+  List,
+  CheckList,
+  OrderedList,
+  Table
+};

--- a/src/parse/nodes/index.js
+++ b/src/parse/nodes/index.js
@@ -1,0 +1,4 @@
+import BlockNodes from './block.js';
+import InlineNodes from './inline.js';
+
+module.exports = Object.assign({}, BlockNodes, InlineNodes);

--- a/src/parse/nodes/inline.js
+++ b/src/parse/nodes/inline.js
@@ -1,0 +1,95 @@
+import Node from './Node.js';
+
+const IMAGE_REGEX = /^!\[([^\]]*)?\]\(([^\)]+)\)$/;
+const LINK_REGEX = /^\[([^\]]*)?\]\(([^\)]+)\)$/;
+
+class Text extends Node {
+  constructor(text) {
+    super('text', 'inline');
+    this.value = text;
+  }
+}
+
+class Html extends Node {
+  constructor(text) {
+    super('html', 'inline');
+    this.value = text;
+  }
+}
+
+class HtmlComment extends Node {
+  constructor(text) {
+    super('htmlcomment', 'inline');
+    this.value = text;
+  }
+}
+
+class Em extends Node {
+  constructor(text) {
+    super('em', 'inline');
+    this.value = text;
+  }
+}
+
+class Italic extends Node {
+  constructor(text) {
+    super('italic', 'inline');
+    this.value = text;
+  }
+}
+class EmItalic extends Node {
+  constructor(text) {
+    super('emitalic', 'inline');
+    this.value = text;
+  }
+}
+class Strikethrough extends Node {
+  constructor(text) {
+    super('strikethrough', 'inline');
+    this.value = text;
+  }
+}
+
+class InlineCode extends Node {
+  constructor(text) {
+    super('code', 'inline');
+    this.value = text;
+  }
+}
+
+class Image extends Node {
+  constructor(text) {
+    const match = text.match(IMAGE_REGEX);
+    if (!match) {
+      throw new Error(`Invalid image syntax: ${text}`);
+    }
+    super('image', 'inline');
+    this.alt = match[1] || '';
+    this.src = match[2] || '';
+  }
+}
+
+class Link extends Node {
+  constructor(text) {
+    const match = text.match(LINK_REGEX);
+    if (!match) {
+      throw new Error(`Invalid link syntax: ${text}`);
+    }
+    super('link', 'inline');
+    this.title = match[1] || '';
+    this.href = match[2] || '';
+  }
+}
+
+export default {
+  Text,
+  Html,
+  HtmlComment,
+  Em,
+  Italic,
+  EmItalic,
+  Strikethrough,
+  InlineCode,
+  Image,
+  Link
+};

--- a/src/parse/parser/block.js
+++ b/src/parse/parser/block.js
@@ -1,0 +1,122 @@
+import parseInline from './inline.js';
+import nodes from '../nodes/block.js';
+import helper from './helper.js';
+
+const HEADING_REGEX = /^(#{1,})\s?(.+)$/;
+const ULIST_REGEX = /^(\s*)?(?:\-|\*)\s*(.+)$/;
+const OLIST_REGEX = /^(\s*)?([0-9]+)\.\s*(.+)$/;
+const HORIZONTAL_RULE_REGEX = /^[\*\-_\s]+$/;
+const CODE_REGEX = /^[`~]{3}(.*)$/;
+const BLOCKQUOTE_REGEX = /^(>{1,})\s?(.+)$/;
+const LINEBREAK_REGEX = /(.+?)[\u0020]{2}$/;
+const TABLE_REGEX = /(?:\s*)?\|(.+)\|(?:\s*)$/;
+
+const MODE_DEFAULT = 0;
+const MODE_CODE = 1;
+const MODE_TABLE = 2; // not implement yet
+
+export default str => {
+  const ast = [];
+
+  if (!/\n$/.test(str)) {
+    str += '\n';
+  }
+
+  let stack = '';
+  let line = '';
+  let mode = MODE_DEFAULT;
+  let tables = [];
+  let match;
+
+  const parseParagraph = stack => {
+    if (tables.length > 0) {
+      ast.push(new nodes.Table(tables));
+      tables = [];
+    }
+    if (!helper.isEmpty(stack)) {
+      ast.push(new nodes.Paragraph(stack));
+    }
+  };
+
+  for (let i = 0; i < str.length; ++i) {
+    const char = str[i];
+
+    // Skip carriage return
+    if (char === '\r') {
+      continue;
+    }
+
+    if (char === '\n') {
+      if (null !== (match = line.match(LINEBREAK_REGEX))) {
+        parseParagraph(stack + match[1]);
+        stack = '';
+      } else if (CODE_REGEX.test(line)) {
+        if (mode === MODE_CODE) {
+          ast.push(new nodes.Code(stack.trim()));
+          mode = MODE_DEFAULT;
+        } else {
+          parseParagraph(stack);
+          mode = MODE_CODE;
+        }
+        stack = '';
+      } else if (null !== (match = line.match(BLOCKQUOTE_REGEX))) {
+        parseParagraph(stack);
+        stack = '';
+        ast.push(new nodes.Blockquote(match[2], match[1].length));
+      } else if (HORIZONTAL_RULE_REGEX.test(line) && line.split(/[\*\-_]/).length > 3) {
+        parseParagraph(stack);
+        stack = '';
+        ast.push(new nodes.Horizontal());
+      } else if (null !== (match = line.match(HEADING_REGEX))) {
+        parseParagraph(stack);
+        stack = '';
+        ast.push(new nodes.Heading(match[2], match[1].length));
+      } else if (null !== (match = line.match(ULIST_REGEX))) {
+        parseParagraph(stack);
+        stack = '';
+        const prev = ast[ast.length - 1];
+        const check = match[2].match(/^\[(x|\u0020)?\]\s?(.+)$/);
+        let level = 1;
+        if (prev && (prev.name === 'list' || prev.name === 'checklist')) {
+          const indent = (match[1] || '').length;
+          if (prev.level * 2 <= indent) {
+            level = prev.level + 1
+          } else if (prev.level === indent) {
+            level = prev.level
+          } else {
+            level = prev.level - 1
+          }
+        }
+        const list = check ? new nodes.CheckList(check[2], check[1] === 'x', level) : new nodes.List(match[2], level);
+        ast.push(list);
+      } else if (null !== (match = line.match(OLIST_REGEX))) {
+        parseParagraph(stack);
+        stack = '';
+        const prev = ast[ast.length - 1];
+        let level = 1;
+        if (prev && (prev.name === 'orderedlist')) {
+          const indent = (match[1] || '').length;
+          if (prev.level * 2 <= indent) {
+            level = prev.level + 1
+          } else if (prev.level === indent) {
+            level = prev.level
+          } else {
+            level = prev.level - 1
+          }
+        }
+        const list = new nodes.OrderedList(match[3], (match[2] | 0), level);
+        ast.push(list);
+      } else if (null !== (match = line.match(TABLE_REGEX))) {
+        tables.push(line);
+        stack = '';
+      } else {
+        stack += line !== '' ? `${line}\n` : '';
+      }
+      line = '';
+    } else {
+      line += char;
+    }
+  }
+  parseParagraph(stack.slice(0, -1));
+  return ast;
+};

--- a/src/parse/parser/helper.js
+++ b/src/parse/parser/helper.js
@@ -1,0 +1,10 @@
+const EMPTY_REGEX = /^\s*$/;
+
+const isEmpty = str => {
+  return str.length === 0 || EMPTY_REGEX.test(str);
+};
+
+export default {
+  isEmpty
+};
+

--- a/src/parse/parser/index.js
+++ b/src/parse/parser/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./block.js');

--- a/src/parse/parser/inline.js
+++ b/src/parse/parser/inline.js
@@ -1,0 +1,229 @@
+import nodes from '../nodes/inline.js';
+import helper from './helper.js';
+
+const MODE_DEFAULT = 0;
+const MODE_ASTERISK = 1;
+const MODE_ASTERISK_DOUBLE = 2;
+const MODE_ASTERISK_TRIPLE = 3;
+const MODE_UNDERLINE = 4;
+const MODE_UNDERLINE_DOUBLE = 5;
+const MODE_UNDERLINE_TRIPLE = 6;
+const MODE_STRIKETHROUGH = 7;
+const MODE_IMAGE = 8;
+const MODE_LINK = 9;
+const MODE_INLINE_CODE = 10;
+
+export default text => {
+  const ast = [];
+
+  let stack = '';
+  let mode = MODE_DEFAULT;
+  let escapeSequence = false;
+  const html = [];
+
+  for (let i = 0; i < text.length; ++i) {
+    const char = text[i];
+
+    if (escapeSequence === true) {
+      stack += char;
+      escapeSequence = false;
+      continue;
+    }
+
+    switch (char) {
+      case "*":
+        if (text[i + 1] === '*') {
+          i++;
+          if (text[i + 1] === '*') {
+            i++;
+            if (mode === MODE_ASTERISK_TRIPLE) {
+              ast.push(new nodes.EmItalic(stack));
+              mode = MODE_DEFAULT;
+            } else {
+              if (!helper.isEmpty(stack)) {
+                ast.push(new nodes.Text(stack));
+              }
+              mode = MODE_ASTERISK_TRIPLE;
+            }
+            stack = '';
+          } else {
+            if (mode === MODE_ASTERISK_DOUBLE) {
+              ast.push(new nodes.Em(stack));
+              mode = MODE_DEFAULT;
+            } else {
+              if (!helper.isEmpty(stack)) {
+                ast.push(new nodes.Text(stack));
+              }
+              mode = MODE_ASTERISK_DOUBLE;
+            }
+            stack = '';
+          }
+          continue;
+        }
+        if (mode === MODE_ASTERISK) {
+          ast.push(new nodes.Italic(stack));
+          mode = MODE_DEFAULT;
+        } else {
+          if (!helper.isEmpty(stack)) {
+            ast.push(new nodes.Text(stack));
+          }
+          mode = MODE_ASTERISK;
+        }
+        stack = '';
+        continue;
+      case "_":
+        if (text[i + 1] === '_') {
+          i++;
+          if (text[i + 1] === '_') {
+            i++;
+            if (mode === MODE_UNDERLINE_TRIPLE) {
+              ast.push(new nodes.EmItalic(stack));
+              mode = MODE_DEFAULT;
+            } else {
+              if (!helper.isEmpty(stack)) {
+                ast.push(new nodes.Text(stack));
+              }
+              mode = MODE_UNDERLINE_TRIPLE;
+            }
+            stack = '';
+          } else {
+            if (mode === MODE_UNDERLINE_DOUBLE) {
+              ast.push(new nodes.Em(stack));
+              mode = MODE_DEFAULT;
+            } else {
+              if (!helper.isEmpty(stack)) {
+                ast.push(new nodes.Text(stack));
+              }
+              mode = MODE_UNDERLINE_DOUBLE;
+            }
+            stack = '';
+          }
+          continue;
+        }
+        if (mode === MODE_UNDERLINE) {
+          ast.push(new nodes.Italic(stack));
+          mode = MODE_DEFAULT;
+        } else {
+          if (!helper.isEmpty(stack)) {
+            ast.push(new nodes.Text(stack));
+          }
+          mode = MODE_UNDERLINE;
+        }
+        stack = '';
+        continue;
+      case "~":
+        if (text[i + 1] === '~') {
+          i++;
+          if (mode === MODE_STRIKETHROUGH) {
+            ast.push(new nodes.Strikethrough(stack));
+            mode = MODE_DEFAULT;
+          } else {
+            if (!helper.isEmpty(stack)) {
+              ast.push(new nodes.Text(stack));
+            }
+            mode = MODE_STRIKETHROUGH;
+          }
+          stack = '';
+          continue;
+        }
+        stack += char;
+        continue;
+      case "`":
+        if (mode === MODE_INLINE_CODE) {
+          ast.push(new nodes.InlineCode(stack));
+          mode = MODE_DEFAULT;
+        } else {
+          if (!helper.isEmpty(stack)) {
+            ast.push(new nodes.Text(stack));
+          }
+          mode = MODE_INLINE_CODE;
+        }
+        stack = '';
+        continue;
+      case "<":
+        if (!helper.isEmpty(stack)) {
+          if (html.length === 0) {
+            ast.push(new nodes.Text(stack));
+          } else {
+            html[html.length - 1] += stack;
+          }
+          stack = '';
+        }
+        let c = char;
+        do {
+          stack += c;
+          c = text[++i];
+        } while(c != ">");
+        stack += c;
+        if (stack[1] === '/') {
+          const h = html.pop() + stack;
+          ast.push(new nodes.Html(h));
+        } else if (stack[1] === '!') {
+          ast.push(new nodes.HtmlComment(stack));
+        } else {
+          html.push(stack);
+        }
+        stack = '';
+        continue;
+      case "!":
+        if (!helper.isEmpty(stack)) {
+          ast.push(new nodes.Text(stack));
+        }
+        stack = '';
+        mode = MODE_IMAGE;
+        stack = char;
+        continue;
+      case "[":
+        if (mode !== MODE_IMAGE) {
+          if (!helper.isEmpty(stack)) {
+            ast.push(new nodes.Text(stack));
+          }
+          mode = MODE_LINK;
+          stack = char;
+          continue
+        }
+        stack += char;
+        continue;
+      case ")":
+        stack += char;
+        if (mode === MODE_IMAGE) {
+          ast.push(new nodes.Image(stack));
+          mode = MODE_DEFAULT;
+          stack = '';
+        } else if (mode === MODE_LINK) {
+          ast.push(new nodes.Link(stack));
+          mode = MODE_DEFAULT;
+          stack = '';
+        } else {
+          stack += char;
+        }
+        continue;
+      case "\\":
+        escapeSequence = true;
+        continue;
+      default:
+        stack += char;
+        break;
+    }
+  }
+  if (!helper.isEmpty(stack)) {
+    const prev = ast[ast.length - 1];
+    if (!prev || mode === MODE_DEFAULT) {
+      ast.push(new nodes.Text(stack));
+    } else {
+      let prefix = '';
+      switch (mode) {
+        case MODE_ASTERISK: prefix = '*'; break;
+        case MODE_ASTERISK_DOUBLE: prefix = '**'; break;
+        case MODE_ASTERISK_TRIPLE: prefix = '**'; break;
+        case MODE_UNDERLINE: prefix = '_'; break;
+        case MODE_UNDERLINE_DOUBLE: prefix = '__'; break;
+        case MODE_UNDERLINE_TRIPLE: prefix = '___'; break;
+        case MODE_STRIKETHROUGH: prefix = '~~'; break;
+        case MODE_INLINE_CODE: prefix = '`'; break;
+      }
+      prev.value += `${prefix}${stack}`;
+    }
+  }
+  return ast;
+};

--- a/src/parse/parser/syntax-error.js
+++ b/src/parse/parser/syntax-error.js
@@ -1,0 +1,5 @@
+export default class SyntaxError extends Error {
+  constructor(message) {
+    super(message);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3530,11 +3530,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-tree-parser@^0.12.4:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/markdown-tree-parser/-/markdown-tree-parser-0.12.4.tgz#105b0ee76be06627a614ae2909a75b9e6a576776"
-  integrity sha512-+/BRwmwNupvy1y++mEz9xiKLaOP9tVUncmXL+i2AQymvsXB0Qc7X/CWCVfOQm0nch9JkQy4FW6GdMbW5o15eYQ==
-
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"


### PR DESCRIPTION
- markdown-tree-parser の字句解析の処理でタイポなどのバグが多数発生していた
  - markdown-tree-parser のソースコードを直接移植して修正する
  - webpack 上で動くように修正する
- markdown-tree-parser をアンインストールする